### PR TITLE
Fix error reporting in runCodex utility

### DIFF
--- a/runCodex.js
+++ b/runCodex.js
@@ -3,7 +3,11 @@ const { exec } = require("child_process");
 function runCodex(prompt, cwd = process.cwd()) {
   return new Promise((resolve, reject) => {
     exec(`codex "${prompt}"`, { cwd }, (err, stdout, stderr) => {
-      if (err) return reject(stderr);
+      if (err) {
+        const error = new Error(stderr || err.message);
+        error.code = err.code;
+        return reject(error);
+      }
       resolve(stdout);
     });
   });


### PR DESCRIPTION
## Summary
- improve `runCodex` error handling

## Testing
- `node runCodex.js` (fails because `codex` command isn't available)