### PR TITLE
test: cover runCodex

### DIFF
--- a/__tests__/runCodex.test.js
+++ b/__tests__/runCodex.test.js
@@ -1,0 +1,17 @@
+jest.mock('child_process', () => ({
+  exec: jest.fn((cmd, options, cb) => cb(null, 'out', ''))
+}));
+
+const runCodex = require('../runCodex');
+
+const { exec } = require('child_process');
+
+test('runCodex executes codex command in cwd', async () => {
+  const cwd = process.cwd();
+  await runCodex('foo');
+  expect(exec).toHaveBeenCalledWith(
+    'codex "foo"',
+    { cwd },
+    expect.any(Function)
+  );
+});

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
     "codex": "^0.2.3",
     "configure": "^0.0.1",
     "husky": "^9.1.7",
+    "jest": "^29.7.0",
     "semantic-release": "^24.2.3",
     "to": "^0.2.9"
   },
   "scripts": {
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "test": "jest"
   }
 }

--- a/runCodex.js
+++ b/runCodex.js
@@ -9,7 +9,10 @@ function runCodex(prompt, cwd = process.cwd()) {
   });
 }
 
-// Run it once
-runCodex("Create a README that says hello", "C:/Projects/codex-playground")
-  .then(output => console.log("Codex said:\n", output))
-  .catch(err => console.error("Codex failed:\n", err));
+module.exports = runCodex;
+
+if (require.main === module) {
+  runCodex("Create a README that says hello", "C:/Projects/codex-playground")
+    .then(output => console.log("Codex said:\n", output))
+    .catch(err => console.error("Codex failed:\n", err));
+}


### PR DESCRIPTION
## Summary
- export `runCodex` and add CLI guard
- create a Jest test for `runCodex`
- add Jest to dev dependencies and wire up `npm test`

## Testing
- `npm test` *(fails: jest not found)*