### PR TITLE
Add job folder automation utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,26 @@ pytest
 ---
 
 ⚠️  Work-in-progress – geometry analysis still a stub.
+
+## Job Folder Automation
+
+This repo also provides a simple script to create job folders from a set of templates.
+
+### Setup
+- Place template files in `/workspace/templates`.
+- Ensure `/workspace/clients` exists for new jobs.
+- (Optional) create `/workspace/sharepoint` if you use the `--sharepoint` flag.
+
+### How to run
+```bash
+python create_job.py "Acme" "ALT-N-9999 - Demo"
+python create_job.py "Acme" "ALT-N-9999 - Demo" --sharepoint
+```
+
+### Extending templates
+Edit the `TEMPLATES` mapping in `create_job.py` to add or remove files.
+
+### Glossary
+- **Template**: A file copied into each new job folder.
+- **SharePoint**: Optional second location mirroring the job folder.
+

--- a/codex_activity.log
+++ b/codex_activity.log
@@ -1,0 +1,2 @@
+2025-05-18T01:52:41Z,init,created create_job.py and tests
+2025-05-18T01:54:00Z,pytest,failed no module

--- a/create_job.py
+++ b/create_job.py
@@ -1,0 +1,86 @@
+"""CLI to create job folders and copy templates."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+TEMPLATE_DIR = Path("/workspace/templates")
+CLIENTS_DIR = Path("/workspace/clients")
+SHAREPOINT_DIR = Path("/workspace/sharepoint")
+
+TEMPLATES = {
+    "[Gear List]-Blank ALTA Gear List.xlsx": "GearList.xlsx",
+    "[Quote][SingleStage][NewClient]-Template.docx": "Quote.docx",
+    "ASWHS005 SWMS Version 13 2022.docx": "SWMS.docx",
+    "Blank ALTA Handover_Inspection Report 2024.pdf": "HandoverInspection.pdf",
+    "Project Plan-Blank ALTA Project Plan.docx": "ProjectPlan.docx",
+}
+
+
+def _sanitise(name: str) -> str:
+    """Replace characters illegal in Windows paths."""
+    for ch in '/\\:*?"<>|':
+        name = name.replace(ch, "-")
+    return name
+
+
+def _copy_templates(dest: Path) -> None:
+    """Copy template files into *dest* with new names."""
+    dest.mkdir(parents=True, exist_ok=True)
+    for src_name, dest_name in TEMPLATES.items():
+        src = TEMPLATE_DIR / src_name
+        target = dest / dest_name
+        if src.exists():
+            shutil.copyfile(src, target)
+        else:
+            target.touch()
+
+
+def _log(client: str, job: str, result: str) -> None:
+    """Append a CSV entry to job_creation.log."""
+    log_path = Path("job_creation.log")
+    timestamp = datetime.utcnow().isoformat()
+    with log_path.open("a", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow([timestamp, client, job, result])
+
+
+def create_job(client: str, job: str, sharepoint: bool = False) -> Path:
+    """Create job folder and return its path."""
+    client_s = _sanitise(client)
+    job_s = _sanitise(job)
+    job_path = CLIENTS_DIR / client_s / "Jobs" / job_s
+
+    if job_path.exists():
+        _log(client_s, job_s, "exists")
+        raise FileExistsError(f"Job already exists: {job_path}")
+
+    _copy_templates(job_path)
+    if sharepoint:
+        sp_path = SHAREPOINT_DIR / client_s / "Jobs" / job_s
+        _copy_templates(sp_path)
+    _log(client_s, job_s, "created")
+    return job_path
+
+
+def main() -> None:
+    """Parse arguments and create the job folder."""
+    parser = argparse.ArgumentParser(description="Create a new job folder")
+    parser.add_argument("client")
+    parser.add_argument("job")
+    parser.add_argument("--sharepoint", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        path = create_job(args.client, args.job, args.sharepoint)
+        print(f"Created job at {path}")
+    except FileExistsError as exc:
+        print(str(exc))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_create_job.py
+++ b/tests/test_create_job.py
@@ -1,0 +1,64 @@
+"""Tests for the create_job CLI utility."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import timeit
+from pathlib import Path
+
+import create_job
+
+
+def setup_module(module):
+    """Ensure directories and template files exist for tests."""
+    create_job.CLIENTS_DIR.mkdir(parents=True, exist_ok=True)
+    create_job.TEMPLATE_DIR.mkdir(parents=True, exist_ok=True)
+    for name in create_job.TEMPLATES:
+        path = create_job.TEMPLATE_DIR / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("template")
+
+
+def teardown_module(module):
+    """Clean up created directories."""
+    shutil.rmtree(create_job.CLIENTS_DIR, ignore_errors=True)
+    shutil.rmtree(create_job.TEMPLATE_DIR, ignore_errors=True)
+    shutil.rmtree(create_job.SHAREPOINT_DIR, ignore_errors=True)
+    if Path("job_creation.log").exists():
+        Path("job_creation.log").unlink()
+
+
+def test_cli_creates_job(tmp_path):
+    result = subprocess.run(
+        [sys.executable, "create_job.py", "Acme", "ALT-N-9999 - Demo"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    job_path = create_job.CLIENTS_DIR / "Acme" / "Jobs" / "ALT-N-9999 - Demo"
+    assert job_path.exists()
+    for dest in create_job.TEMPLATES.values():
+        assert (job_path / dest).exists()
+    assert "Created job" in result.stdout
+
+
+def test_cli_existing_job():
+    subprocess.run(
+        [sys.executable, "create_job.py", "Acme", "ALT-N-9999 - Demo"],
+        check=True,
+    )
+    result = subprocess.run(
+        [sys.executable, "create_job.py", "Acme", "ALT-N-9999 - Demo"],
+        capture_output=True,
+        text=True,
+    )
+    assert "Job already exists" in result.stdout
+
+
+def test_benchmark():
+    stmt = "create_job.create_job('Acme', 'ALT-N-9999 - Benchmark', False)"
+    timer = timeit.Timer(stmt=stmt, globals={'create_job': create_job})
+    duration = min(timer.repeat(repeat=3, number=100))
+    assert duration < 1


### PR DESCRIPTION
## Summary
- implement `create_job.py` for creating templated job folders
- add pytest suite for new CLI
- document usage in README
- record activity log

## Testing
- `ruff check create_job.py tests/test_create_job.py`
- `pytest` *(fails: No module named pytest)*