### PR TITLE
Move job folder automation under estimations

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,17 @@ The source code now resides under `alta-monorepo/apps/scaffold-audit/src`.
   ```powershell
   python pytest.py alta-monorepo/apps/scaffold-audit/tests
   ```
+- Create a job folder
+  ```powershell
+  python -m folder_automation "ClientName" "JobName"
+  ```
 
 ## Glossary
 
 - **DXF** – Drawing Exchange Format used by many CAD programs.
 - **Audit** – Automatic check of a drawing against safety rules.
 - **Stub** – Lightweight placeholder module used when a dependency is missing.
+- **Template** – A starter document copied into each new job folder.
 
 ## Monorepo layout
 

--- a/alta-monorepo/apps/estimations/folder-automation/README.md
+++ b/alta-monorepo/apps/estimations/folder-automation/README.md
@@ -1,7 +1,7 @@
 ## In one sentence, what this folder does
-This folder holds the **folder-automation** tool. It creates project folders automatically.
+This folder contains the **folder-automation** tool. It sets up client job folders with template documents.
 
-Follow the setup guide in the root `README.md`, then run:
+After following the setup steps in the repository `README.md`, run it with:
 ```powershell
-python -m folder_automation
+python -m folder_automation "ClientName" "JobName"
 ```

--- a/alta-monorepo/apps/estimations/folder-automation/src/README.md
+++ b/alta-monorepo/apps/estimations/folder-automation/src/README.md
@@ -1,1 +1,2 @@
 ## In one sentence, what this folder does
+Python package containing the code for folder-automation.

--- a/alta-monorepo/apps/estimations/folder-automation/src/folder_automation/__init__.py
+++ b/alta-monorepo/apps/estimations/folder-automation/src/folder_automation/__init__.py
@@ -1,0 +1,6 @@
+"""## In one sentence, what this file does
+Package initializer for folder automation."""
+
+from .main import create_job_structure, main
+
+__all__ = ["create_job_structure", "main"]

--- a/alta-monorepo/apps/estimations/folder-automation/src/folder_automation/main.py
+++ b/alta-monorepo/apps/estimations/folder-automation/src/folder_automation/main.py
@@ -1,0 +1,82 @@
+"""## In one sentence, what this file does
+Create a job folder and copy templated documents into it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+# Default locations (Windows paths). Adjust if running on another OS.
+BASE_DIR = Path(r"C:\Users\knigh\Sync\ALTA Front\Clients")
+TEMPLATE_DIR = Path(r"C:\Users\knigh\Sync\ALTA Front\Templates")
+
+# Mapping of template filename to output filename pattern
+TEMPLATES = {
+    "[Gear List]-Blank ALTA Gear List.xlsx": "{job}Gearlist.xlsx",
+    "[Quote][SingleStage][NewClient]-Template.docx": "{job} Quotation.docx",
+    "ASWHS005 SWMS Version 13 2022.docx": "{job} SWMS.docx",
+    # Long file name split for readability
+    "Blank ALTA Handover_Inspection Report 2024.pdf": (
+        "{job} HandoverInspectionCertificate.pdf"
+    ),
+    "Project Plan-Blank ALTA Project Plan.docx": "{job} ProjectPlan.docx",
+}
+
+
+def create_job_structure(
+    client_name: str,
+    job_name: str,
+    base_dir: Path = BASE_DIR,
+    template_dir: Path = TEMPLATE_DIR,
+) -> list[Path]:
+    """Create directories and copy template files.
+
+    Returns a list of created file paths.
+    """
+    client_dir = base_dir / client_name
+    job_dir = client_dir / job_name
+
+    # Ensure the client directory exists but do not fail if already present
+    client_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create the job directory only if it does not already exist
+    job_dir.mkdir(exist_ok=True)
+
+    created_files: list[Path] = []
+
+    for template_name, out_pattern in TEMPLATES.items():
+        src = template_dir / template_name
+        dst = job_dir / out_pattern.format(job=job_name)
+
+        # Skip if the destination file already exists
+        if dst.exists():
+            continue
+
+        # Copy file metadata as well (e.g., modification time)
+        shutil.copy2(src, dst)
+        created_files.append(dst)
+
+    return created_files
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point allowing future UI integration."""
+    parser = argparse.ArgumentParser(description="Create a job folder from templates")
+    parser.add_argument("client_name", help="Name of the client")
+    parser.add_argument("job_name", help="Name of the job")
+    args = parser.parse_args(argv)
+
+    files = create_job_structure(args.client_name, args.job_name)
+
+    print(f"Created job folder at: {BASE_DIR / args.client_name / args.job_name}")
+    for f in files:
+        print(f"Copied {f.name}")
+
+    if not files:
+        print("No new files were created (they may already exist).")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution only
+    main()

--- a/alta-monorepo/apps/estimations/folder-automation/tests/test_folder_automation.py
+++ b/alta-monorepo/apps/estimations/folder-automation/tests/test_folder_automation.py
@@ -1,0 +1,61 @@
+"""## In one sentence, what this file does
+Unit tests for the folder-automation tool.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Make the package importable during tests
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from folder_automation.main import TEMPLATES, create_job_structure
+
+
+class TestJobFolderAutomation(unittest.TestCase):
+    def setUp(self) -> None:
+        # Create temporary directories for base and templates
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.base_dir = Path(self.temp_dir.name) / "Clients"
+        self.template_dir = Path(self.temp_dir.name) / "Templates"
+        self.base_dir.mkdir()
+        self.template_dir.mkdir()
+
+        # Create dummy template files
+        for name in TEMPLATES.keys():
+            (self.template_dir / name).write_text("template")
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def test_create_job_structure_creates_files(self) -> None:
+        files = create_job_structure(
+            "Acme", "Job1", base_dir=self.base_dir, template_dir=self.template_dir
+        )
+        expected = {
+            self.base_dir
+            / "Acme"
+            / "Job1"
+            / pattern.format(job="Job1")
+            for pattern in TEMPLATES.values()
+        }
+        self.assertEqual(set(files), expected)
+        for f in expected:
+            self.assertTrue(f.exists())
+
+    def test_create_job_structure_is_idempotent(self) -> None:
+        create_job_structure(
+            "Acme", "Job2", base_dir=self.base_dir, template_dir=self.template_dir
+        )
+        # Run again; no files should be reported created
+        files = create_job_structure(
+            "Acme", "Job2", base_dir=self.base_dir, template_dir=self.template_dir
+        )
+        self.assertEqual(files, [])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/codex_activity.log
+++ b/codex_activity.log
@@ -19,3 +19,12 @@
 2025-05-19T02:10:55Z,move files,success
 2025-05-19T02:10:56Z,ruff fix,success
 2025-05-19T02:10:57Z,pytest,success
+2025-05-19T03:30:42Z,npm lint,error: missing script
+2025-05-19T03:31:33Z,create job-folder-automation,success
+2025-05-19T03:32:03Z,ruff fix,success
+2025-05-19T03:32:21Z,ruff fix,success
+2025-05-19T03:32:40Z,ruff fix,success
+2025-05-19T03:32:43Z,pytest,success
+2025-05-19T03:32:47Z,npm lint,error: missing script
+2025-05-19T08:53:20Z,pytest,success
+2025-05-19T08:53:20Z,ruff fix,success

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 # Point Poetry to the relocated package under the monorepo
 packages = [
     { include = "scaffold_audit", from = "alta-monorepo/apps/scaffold-audit/src" },
+    { include = "folder_automation", from = "alta-monorepo/apps/estimations/folder-automation/src" },
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
## Summary
- move job folder automation into estimations/folder-automation
- update README docs to reflect new module name
- include folder_automation package in pyproject

## Testing
- `python pytest.py alta-monorepo/apps/estimations/folder-automation/tests`
- `ruff check --fix alta-monorepo/apps/estimations/folder-automation/src/folder_automation/main.py alta-monorepo/apps/estimations/folder-automation/src/folder_automation/__init__.py alta-monorepo/apps/estimations/folder-automation/tests/test_folder_automation.py`