### PR TITLE
feat: comment unused pythonocc-core dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+## In one sentence, what this file does
+Simple instructions for installing and using the scaffold audit tools.
+
 ## Setup
 
 - Create and activate a virtual environment
@@ -8,6 +11,10 @@
 - Install the package in editable mode
   ```powershell
   pip install -e .
+  ```
+  # Optional: install pythonocc-core if you need 3D features
+  ```powershell
+  pip install pythonocc-core==7.6
   ```
 
 ## How to run

--- a/codex_activity.log
+++ b/codex_activity.log
@@ -28,3 +28,6 @@
 2025-05-19T03:32:47Z,npm lint,error: missing script
 2025-05-19T08:53:20Z,pytest,success
 2025-05-19T08:53:20Z,ruff fix,success
+2025-05-19T09:34:15Z,investigate pythonocc-core,unused
+2025-05-19T09:34:24Z,ruff fix,success
+2025-05-19T09:35:21Z,pytest,success

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
+## In one sentence, what this file does
+# Build and package configuration for the project
 [tool.poetry]
 name = "scaffold-audit"
 version = "0.1.0"
@@ -15,7 +17,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.11"
 ezdxf = "^1.1"
-pythonocc-core = "^7.6" # optional heavy dependency; not used yet
+# pythonocc-core = "^7.6" # optional heavy dependency; not used yet
 trimesh = "^4.0"
 opencv-python = {version = "^4.8", optional = true}
 jinja2 = "^3.1"


### PR DESCRIPTION
## Summary
- comment out unused heavy dependency `pythonocc-core`
- document optional install in README
- log activity

## Testing
- `ruff check --fix .`
- `python pytest.py alta-monorepo/apps/scaffold-audit/tests`
