### PR TITLE
fix(folder-automation): create subdirs for templates

### DIFF
--- a/alta-monorepo/apps/estimations/folder-automation/src/folder_automation/main.py
+++ b/alta-monorepo/apps/estimations/folder-automation/src/folder_automation/main.py
@@ -59,6 +59,9 @@ def create_job_structure(
             print(f"Template missing: {src}")
             continue
 
+        # Ensure any nested directories exist before copying
+        dst.parent.mkdir(parents=True, exist_ok=True)
+
         # Copy file metadata as well (e.g., modification time)
         shutil.copy2(src, dst)
         created_files.append(dst)

--- a/alta-monorepo/apps/estimations/folder-automation/tests/test_folder_automation.py
+++ b/alta-monorepo/apps/estimations/folder-automation/tests/test_folder_automation.py
@@ -56,6 +56,20 @@ class TestJobFolderAutomation(unittest.TestCase):
         )
         self.assertEqual(files, [])
 
+    def test_create_job_structure_creates_subdir_file(self) -> None:
+        files = create_job_structure(
+            "Beta", "Job3", base_dir=self.base_dir, template_dir=self.template_dir
+        )
+        nested = (
+            self.base_dir
+            / "Beta"
+            / "Job3"
+            / "Handover"
+            / "Inspection Certificate Job3.pdf"
+        )
+        self.assertIn(nested, files)
+        self.assertTrue(nested.exists())
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/codex_activity.log
+++ b/codex_activity.log
@@ -47,3 +47,5 @@
 2025-05-19T14:19:38Z,ruff fix,success
 2025-05-19T14:19:40Z,pytest,success
 2025-05-26T12:12:19Z, create alta_estimator project skeleton, success
+2025-05-29T05:44:27Z,ruff fix,success
+2025-05-29T05:44:27Z,pytest,success


### PR DESCRIPTION
## Summary
- ensure nested directories exist before copying templates
- add unit test for subdirectory template files

## Testing
- `ruff check --fix`
- `python pytest.py alta-monorepo/apps/estimations/folder-automation/tests`
