### PR TITLE
feat: add basic estimation calculator

### DIFF
--- a/alta-monorepo/apps/estimations/estimation-tool/README.md
+++ b/alta-monorepo/apps/estimations/estimation-tool/README.md
@@ -1,7 +1,21 @@
 ## In one sentence, what this folder does
-This folder contains the **estimation-tool**. It helps calculate project costs quickly.
+This folder contains the **estimation-tool**. It calculates scaffold quotes.
 
-After the setup steps in the root `README.md`, start it with:
+### Setup steps
+- Follow the virtual environment instructions in the root `README.md`.
+- No extra packages are required for this tool.
+
+### How to run
 ```powershell
-python -m estimation_tool
+python -m estimation_tool 10 5
 ```
+This example assumes each component weighs 10kg and you need 5 of them.
+
+### Running the tests
+```powershell
+python pytest.py alta-monorepo/apps/estimations/estimation-tool/tests
+```
+
+### Glossary
+- **Component** – A single scaffolding item such as a tube or board.
+- **Quote** – Calculated price sent to a customer.

--- a/alta-monorepo/apps/estimations/estimation-tool/src/estimation_tool/__init__.py
+++ b/alta-monorepo/apps/estimations/estimation-tool/src/estimation_tool/__init__.py
@@ -1,0 +1,10 @@
+"""## In one sentence, what this file does
+Expose public functions for the estimation tool."""
+
+from .core import calculate_complexity_multiplier, calculate_quote, calculate_tonnage
+
+__all__ = [
+    "calculate_complexity_multiplier",
+    "calculate_quote",
+    "calculate_tonnage",
+]

--- a/alta-monorepo/apps/estimations/estimation-tool/src/estimation_tool/__main__.py
+++ b/alta-monorepo/apps/estimations/estimation-tool/src/estimation_tool/__main__.py
@@ -1,0 +1,48 @@
+"""## In one sentence, what this file does
+Command line interface for quick quotations."""
+from __future__ import annotations
+
+import argparse
+
+from .core import (
+    Component,
+    calculate_complexity_multiplier,
+    calculate_quote,
+    calculate_tonnage,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create argument parser for a minimal demo."""
+    parser = argparse.ArgumentParser(description="Simple scaffolding estimator")
+    parser.add_argument("weight", type=float, help="Weight per component in kg")
+    parser.add_argument("count", type=int, help="Number of components")
+    return parser
+
+
+def main() -> None:
+    """Run a basic calculation from the CLI."""
+    parser = build_parser()
+    args = parser.parse_args()
+
+    component = Component(weight_per_unit=args.weight, quantity=args.count)
+    tonnage = calculate_tonnage([component])
+    multiplier = calculate_complexity_multiplier()
+    quote = calculate_quote(
+        base_tonnage=tonnage,
+        material_rate=100,
+        setup_hours=5,
+        daily_rate=50,
+        duration=1,
+        distance=10,
+        transport_rate=1.5,
+        transport_premium=0,
+        equipment_daily_rate=20,
+        profit_percentage=0.1,
+        complexity_multiplier=multiplier,
+    )
+    print(f"Estimated quote: ${quote:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/alta-monorepo/apps/estimations/estimation-tool/src/estimation_tool/core.py
+++ b/alta-monorepo/apps/estimations/estimation-tool/src/estimation_tool/core.py
@@ -1,0 +1,77 @@
+"""## In one sentence, what this file does
+Core math functions for scaffold estimations."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass
+class Component:
+    """Represents a scaffolding component with weight data."""
+
+    weight_per_unit: float
+    quantity: int
+
+    def total_weight(self) -> float:
+        """Return the total weight for this component."""
+        if self.quantity < 0 or self.weight_per_unit < 0:
+            raise ValueError("weight_per_unit and quantity must be non-negative")
+        return self.weight_per_unit * self.quantity
+
+
+def calculate_tonnage(components: Iterable[Component]) -> float:
+    """Sum the weights of all components in tonnes."""
+    total_kg = sum(c.total_weight() for c in components)
+    return total_kg / 1000
+
+
+def calculate_complexity_multiplier(
+    h_factor: float = 1.0,
+    a_factor: float = 1.0,
+    s_factor: float = 1.0,
+    t_factor: float = 1.0,
+) -> float:
+    """Multiply the provided complexity factors."""
+    for factor in (h_factor, a_factor, s_factor, t_factor):
+        if factor <= 0:
+            raise ValueError("complexity factors must be positive")
+    return h_factor * a_factor * s_factor * t_factor
+
+
+def calculate_quote(
+    base_tonnage: float,
+    material_rate: float,
+    setup_hours: float,
+    daily_rate: float,
+    duration: int,
+    distance: float,
+    transport_rate: float,
+    transport_premium: float,
+    equipment_daily_rate: float,
+    profit_percentage: float,
+    complexity_multiplier: float,
+) -> float:
+    """Return the final quote amount."""
+    if any(x < 0 for x in (
+        base_tonnage,
+        material_rate,
+        setup_hours,
+        daily_rate,
+        duration,
+        distance,
+        transport_rate,
+        transport_premium,
+        equipment_daily_rate,
+        profit_percentage,
+        complexity_multiplier,
+    )):
+        raise ValueError("all inputs must be non-negative")
+
+    material_cost = (base_tonnage * material_rate) * complexity_multiplier
+    labor_cost = (setup_hours + daily_rate * duration) * complexity_multiplier
+    transport_cost = distance * transport_rate + transport_premium
+    equipment_cost = duration * equipment_daily_rate
+    subtotal = material_cost + labor_cost + transport_cost + equipment_cost
+    profit_margin = subtotal * profit_percentage
+    return subtotal + profit_margin

--- a/alta-monorepo/apps/estimations/estimation-tool/tests/test_core.py
+++ b/alta-monorepo/apps/estimations/estimation-tool/tests/test_core.py
@@ -1,0 +1,48 @@
+"""## In one sentence, what this file does
+Unit tests for core estimation functions."""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from estimation_tool.core import (
+    Component,
+    calculate_complexity_multiplier,
+    calculate_quote,
+    calculate_tonnage,
+)
+
+
+class CoreTests(unittest.TestCase):
+    """Test calculations for correctness."""
+
+    def test_tonnage(self) -> None:
+        component = Component(weight_per_unit=10, quantity=5)
+        self.assertEqual(calculate_tonnage([component]), 0.05)
+
+    def test_complexity_multiplier(self) -> None:
+        self.assertEqual(calculate_complexity_multiplier(1, 2, 1, 0.5), 1.0)
+
+    def test_calculate_quote(self) -> None:
+        component = Component(weight_per_unit=50, quantity=2)
+        tonnage = calculate_tonnage([component])
+        multiplier = calculate_complexity_multiplier()
+        quote = calculate_quote(
+            base_tonnage=tonnage,
+            material_rate=10,
+            setup_hours=1,
+            daily_rate=5,
+            duration=2,
+            distance=1,
+            transport_rate=1,
+            transport_premium=0,
+            equipment_daily_rate=0,
+            profit_percentage=0.1,
+            complexity_multiplier=multiplier,
+        )
+        self.assertAlmostEqual(round(quote, 2), 14.3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/codex_activity.log
+++ b/codex_activity.log
@@ -49,3 +49,5 @@
 2025-05-26T12:12:19Z, create alta_estimator project skeleton, success
 2025-05-29T05:44:27Z,ruff fix,success
 2025-05-29T05:44:27Z,pytest,success
+2025-06-13T08:33:34Z,ruff fix,success
+2025-06-13T08:33:35Z,pytest,success


### PR DESCRIPTION
## Summary
- add simple scaffolding estimation module with CLI
- include initial unit tests for core logic
- document usage in estimation tool README

## Testing
- `ruff check --fix alta-monorepo/apps/estimations/estimation-tool`
- `python pytest.py alta-monorepo/apps/estimations/estimation-tool/tests`


------
https://chatgpt.com/codex/tasks/task_e_684be1319b508333a7744ca57e678ebf